### PR TITLE
Only default chef-use-rvm to t if rvm is available

### DIFF
--- a/chef-mode.el
+++ b/chef-mode.el
@@ -64,7 +64,7 @@
 (defvar chef-use-bundler t
   "Use `bundle exec knife' if Gemfile exists")
 
-(defvar chef-use-rvm t
+(defvar chef-use-rvm (when (fboundp 'rvm-activate-corresponding-ruby) t)
   "If non-nil, require rvm.el and call rvm-activate-corresponding-ruby on chef repo root before calling knife")
 
 (defvar chef-mode-map (make-sparse-keymap)


### PR DESCRIPTION
This fix is in connection with [adding chef-mode to MELPA](https://github.com/milkypostman/melpa/pull/1760). /cc @webframp
