### PR TITLE
Soft-require rvm.el if available to avoid byte-compilation warnings

### DIFF
--- a/chef-mode.el
+++ b/chef-mode.el
@@ -57,6 +57,8 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'rvm nil t))
+
 
 (defvar chef-knife-command "knife"
   "Knife command to run")


### PR DESCRIPTION
This fix is in connection with [adding chef-mode to MELPA](https://github.com/milkypostman/melpa/pull/1760). /cc @webframp
